### PR TITLE
Freeze cors headers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ asgiref==3.10.0
 certifi==2025.10.5
 charset-normalizer==3.4.3
 Django==5.2.7
+django-cors-headers==4.9.0
 gunicorn==23.0.0
 idna==3.10
 packaging==25.0
@@ -11,4 +12,3 @@ requests==2.32.5
 sqlparse==0.5.3
 urllib3==2.5.0
 whitenoise==6.11.0
-django-cors-headers


### PR DESCRIPTION
Pin django-cors-headers version just in case for reproducibility.